### PR TITLE
fix: remove default runtime identifier from csproj

### DIFF
--- a/dofusdb/dofusdb.csproj
+++ b/dofusdb/dofusdb.csproj
@@ -13,7 +13,6 @@
         <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
         <SelfContained>true</SelfContained>
         <PublishSingleFile>true</PublishSingleFile>
-        <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
By not setting the value we let the framework decide.